### PR TITLE
feat: support plugin name completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,7 @@ If trying to set, get or unset `target-org` or `target-dev-hub` it will suggest 
 ### Metadata component names:
 `sf project deploy (start|validate) (--metadata | -m)`: metadata component names in "type:name" format in your current project.
 
+### Plugin names:
+`sf plugins (inspect|uninstall)`: suggest all plugins (except `uninstall`, which will only get user plugins (installed or linked).
 
 

--- a/src/commands/__fzf_complete.ts
+++ b/src/commands/__fzf_complete.ts
@@ -1,0 +1,32 @@
+import { Command, Args } from '@oclif/core';
+
+export default class __FzfComplete extends Command {
+  public static hidden = true;
+  public static args = {
+    comp: Args.string({
+      required: true,
+    }),
+  };
+  async run(): Promise<void> {
+    const { args } = await this.parse(__FzfComplete);
+
+    let output = '';
+
+    switch (args.comp) {
+      case 'all-plugins':
+        for (const plugin of this.config.plugins) {
+          output += `${plugin.name}\t(${plugin.type})\n`;
+        }
+        break;
+      case 'user-plugins':
+        for (const plugin of this.config.plugins) {
+          if (plugin.type !== 'core') {
+            output += `${plugin.name}\t(${plugin.type})\n`;
+          }
+        }
+        break;
+    }
+
+    this.log(output.slice(0, -1));
+  }
+}

--- a/src/commands/fzf-cmp.ts
+++ b/src/commands/fzf-cmp.ts
@@ -28,9 +28,7 @@ export default class FzfCmp extends Command {
 ${chalk.cyan(`source "${fzfFuncFile}"`)}
 
 2) Test it out, e.g.:
-${chalk.cyan(
-  `$ sf ${process.env.FZF_COMPLETION_TRIGGER || '**'}<TAB>`,
-)}
+${chalk.cyan(`$ sf ${process.env.FZF_COMPLETION_TRIGGER || '**'}<TAB>`)}
 
 Enjoy!
 `,

--- a/src/comp-gen.ts
+++ b/src/comp-gen.ts
@@ -66,7 +66,11 @@ _fzf_complete_sf_post() {
   }`;
   await writeFile(
     fzfFuncFile,
-    format(fzfCompleteFuncTpl, commandsFile, normalize(`${__filename}/../../lib/shell-completion.js`)),
+    format(
+      fzfCompleteFuncTpl,
+      commandsFile,
+      normalize(`${__filename}/../../lib/shell-completion.js`),
+    ),
   );
 
   return fzfFuncFile;

--- a/src/shell-completion.ts
+++ b/src/shell-completion.ts
@@ -1,4 +1,8 @@
 import type { AuthFields } from '@salesforce/core';
+import { promisify } from 'node:util';
+import { exec as nodeExec } from 'node:child_process';
+
+const exec = promisify(nodeExec);
 
 const args = process.argv[2].split(' ');
 
@@ -79,6 +83,10 @@ async function completeCommand(
     (wordToComplete == '-o' || wordToComplete == '--target-org')
   ) {
     output = await getOrgs('scratch');
+  } else if (/^sf plugins inspect/.test(process.argv[2])) {
+    output = (await exec('sf __fzf_complete all-plugins')).stdout;
+  } else if (/^sf plugins (uninstall|unlink|remove)/.test(process.argv[2])) {
+    output = (await exec('sf __fzf_complete user-plugins')).stdout;
   }
 
   return output;


### PR DESCRIPTION
### What does this PR do?
Adds support for plugin name completion to `sf plugins inspect | uninstall`.

plugin data is only available at runtime so this PR adds a hidden `__fzf_complete` that allows to get runtime data in a reliable format.  

```
sf plugins uninstall:  only show user plugins (installed or linked)
```

![Screenshot from 2023-10-08 21-10-12](https://github.com/cristiand391/sf-plugin-fzf-cmp/assets/6853656/3adcc8a5-3350-4876-9490-39d0590454ba)

```
sf plugins inspect: show all plugins
````
![Screenshot from 2023-10-08 21-09-04](https://github.com/cristiand391/sf-plugin-fzf-cmp/assets/6853656/4a62ca72-046f-48d4-99fa-bf006be0909e)

### What issues does this PR fix or reference?
none