### PR TITLE
feat(cmd): automatically select the only match

### DIFF
--- a/src/comp-gen.ts
+++ b/src/comp-gen.ts
@@ -104,7 +104,7 @@ export async function genCompletion(
     commands_file="%s"
     preview_command="jq --arg cmd {} -r '. as \\$commands | map(.id == \\$cmd) | index(true) | \\$commands[.].summary' $commands_file"
 
-    _fzf_complete --reverse --preview "$preview_command" --preview-window wrap,down,1 --prompt="sf> " -- "$@" < <(
+    _fzf_complete --select-1 --reverse --preview "$preview_command" --preview-window wrap,down,1 --prompt="sf> " -- "$@" < <(
       jq -r '.[] | .id' $commands_file
     )
   else


### PR DESCRIPTION
### What does this PR do?
Adds `--select-1` flag to command completion to make fzf automatically select the only match.

This is useful if you know a command part only matches that command, example:

`sf web<TRIGGER>` -> `sf org login web`

### What issues does this PR fix or reference?
