### PR TITLE
feat: add `refresh-cache` hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,11 @@
     "typescript": "^5.3.3"
   },
   "oclif": {
-    "commands": "./lib/commands"
+    "commands": "./lib/commands",
+    "hooks": {
+      "plugins:postinstall": "./lib/hooks/refresh-cache.js",
+      "plugins:postuninstall": "./lib/hooks/refresh-cache.js"
+    }
   },
   "prettier": {
     "singleQuote": true

--- a/src/hooks/refresh-cache.ts
+++ b/src/hooks/refresh-cache.ts
@@ -1,0 +1,8 @@
+import {Hook} from '@oclif/core'
+
+const hook: Hook<'refresh'> = async function (opts) {
+  // this `config` instance already have installed/uninstalled plugins loaded
+  await opts.config.runCommand('fzf-cmp', ['--refresh-cache'])
+}
+
+export default hook


### PR DESCRIPTION
### What does this PR do?

Adds a refresh hook to run `fzf-cmp --refresh-cache` when installing/uninstalling plugins.
See: https://github.com/oclif/plugin-autocomplete/pull/753

### What issues does this PR fix or reference?
